### PR TITLE
Minor login fix & corruption avoidance

### DIFF
--- a/htdocs/include/ticketr.php
+++ b/htdocs/include/ticketr.php
@@ -79,7 +79,8 @@ if(!$complete)
 }
 header("Content-Length: $size");
 session_write_close();
-ob_end_flush();
+// disable output buffering if it was enabled
+if(ob_get_level()) ob_end_flush();
 
 // contents
 $left = $size;


### PR DESCRIPTION
Focusing the username fields currently implies to skip all languages links using tab. First patch adds a tabindex & autofocus in login field. Did not modified other pages since they seem more likely to be used through mouse (at least in my case :-) )
Second one fixes a warning on ob_end_flush in the file download code. Had no time to investigate why this ob_end_flush is there and why a warning is emitted but since I needed to download uncorrupted files I just silented it out.