### PR TITLE
Fixes "File() needs new" JS error in Thunberbird 45

### DIFF
--- a/client/thunderbird-filelink-dl/components/nsDL.js
+++ b/client/thunderbird-filelink-dl/components/nsDL.js
@@ -105,7 +105,7 @@ nsDL.prototype =
     {
       let data = Cc["@mozilla.org/files/formdata;1"].createInstance(Ci.nsIDOMFormData);
       if(msg) data.append("msg", JSON.stringify(msg));
-      if(file) data.append("file", File(file));
+      if(file) data.append("file", new File(file));
       req.send(data);
     }
 


### PR DESCRIPTION
In Thunderbird 45 any attempt to turn an attachment into a DL one fails
with an error about File() needing new operator.
Simply adding new as per the error message fixes the issue